### PR TITLE
Document icon and background image requirements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ When adding a new protocol, include both an icon and a background image that mee
 - **Dimensions:** 1152 × 648 px (16:9)
 - **File size:** under 500 KB
 
-Use the protocol's name as the filename (e.g. `soroswap.png`) and keep it identical between the `icons/` and `backgrounds/` directories.
+Use the protocol's name as the filename in lowercase kebab-case (e.g. `soroswap.png`, `soroban-domains.png`) and keep it identical between the `icons/` and `backgrounds/` directories.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # freighter-protocol-icons
 Maintains a list of icon images for supported protocols on Freighter
+
+## Image requirements
+
+When adding a new protocol, include both an icon and a background image that meet the following specs.
+
+### Icons (`icons/`)
+
+- **Format:** PNG
+- **Dimensions:** 96 × 96 px (square)
+- **File size:** under 20 KB
+
+### Backgrounds (`backgrounds/`)
+
+- **Format:** PNG
+- **Dimensions:** 1152 × 648 px (16:9)
+- **File size:** under 500 KB
+
+Use the protocol's name as the filename (e.g. `soroswap.png`) and keep it identical between the `icons/` and `backgrounds/` directories.


### PR DESCRIPTION
This pull request updates the `README.md` to add clear image requirements for contributing protocol icons and backgrounds. The new documentation specifies the required formats, dimensions, file sizes, and naming conventions for both icon and background images.

Documentation improvements:

* Added a section detailing image requirements for protocol icons and backgrounds, including format, dimensions, file size limits, and naming conventions to be followed when adding new protocols.